### PR TITLE
Fix 2 implement backend

### DIFF
--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'dart:async';
+import 'dart:convert';
+
+void main() {
+  runApp(MaterialApp(
+    home: ApiConnection(),
+  ));
+}
+
+class ApiConnection extends StatefulWidget {
+  @override
+  _ApiConnectionState createState() => _ApiConnectionState();
+}
+
+class _ApiConnectionState extends State<ApiConnection> {
+  Map data = new Map();
+  List userData = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: ListView.builder( //スクロール可能な可変リストを作る
+          itemCount: userData == null ? 0 : userData.length, //受け取る数の定義
+          itemBuilder: (BuildContext context, int index) { //ここに表示したい内容をindexに応じて
+            return Card( //cardデザインを定義:material_design
+              child: Row(
+                children: <Widget>[
+                      Text("${userData[index]["first_name"]} ${userData[index]["last_name"]}"),
+                ],
+              ),
+            );
+          },
+        )
+    );
+  }
+
+  Future getData() async {
+    var url = Uri.parse('https://reqres.in/api/users?page=2');
+    http.Response response = await http.get(url);
+    data = json.decode(response.body); //json->Mapオブジェクトに格納
+    setState(() { //状態が変化した場合によばれる
+      userData = data["data"]; //Map->Listに必要な情報だけ格納
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    getData();
+  }
+}

--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -3,6 +3,8 @@ import 'package:http/http.dart' as http;
 import 'dart:async';
 import 'dart:convert';
 
+
+// TODO:最終的にはWidget部分はこのクラスに書かず切り出したい
 void main() {
   runApp(MaterialApp(
     home: ApiConnection(),
@@ -17,17 +19,20 @@ class ApiConnection extends StatefulWidget {
 class _ApiConnectionState extends State<ApiConnection> {
   Map data = new Map();
   List userData = [];
+  String startData = "0";
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: ListView.builder( //スクロール可能な可変リストを作る
-          itemCount: userData == null ? 0 : userData.length, //受け取る数の定義
-          itemBuilder: (BuildContext context, int index) { //ここに表示したい内容をindexに応じて
-            return Card( //cardデザインを定義:material_design
+        body: ListView.builder(
+          itemCount: userData == null ? 0 : userData.length,
+          // itemCount: startData == null ? 0 : startData.length,
+          itemBuilder: (BuildContext context, int index) {
+            return Card(
               child: Row(
                 children: <Widget>[
                       Text("${userData[index]["first_name"]} ${userData[index]["last_name"]}"),
+                  // Text("${startData}"),
                 ],
               ),
             );
@@ -36,7 +41,18 @@ class _ApiConnectionState extends State<ApiConnection> {
     );
   }
 
-  Future getData() async {
+  // ゲームスタート時に必要なゲームIDを受け取る
+  // Future postStart() async {
+  //   var url = Uri.parse('https://circle-judge-backend.herokuapp.com/start');
+  //   http.Response response = await http.get(url);
+  //   data = json.decode(response.body);
+  //   setState(() {
+  //     startData = data["message"];
+  //   });
+  // }
+
+  // モックAPI
+  Future getUser() async {
     var url = Uri.parse('https://reqres.in/api/users?page=2');
     http.Response response = await http.get(url);
     data = json.decode(response.body); //json->Mapオブジェクトに格納
@@ -45,9 +61,42 @@ class _ApiConnectionState extends State<ApiConnection> {
     });
   }
 
+  // Future postQuestion() async {
+  //   var url = Uri.parse('https://circle-judge-backend.herokuapp.com/question');
+  //   http.Response response = await http.get(url);
+  //   data = json.decode(response.body);
+  //   setState(() {
+  //     questionData = data["data"];
+  //   });
+  // }
+
+  // Future postAnswer() async {
+  //   var url = Uri.parse('https://circle-judge-backend.herokuapp.com/question/answer');
+  //   http.Response response = await http.get(url);
+  //   data = json.decode(response.body);
+  //   setState(() {
+  //     answerData = data["message"];
+  //   });
+  // }
+
+  // Future postResult() async {
+  //   var url = Uri.parse('https://circle-judge-backend.herokuapp.com/result');
+  //   http.Response response = await http.get(url);
+  //   data = json.decode(response.body);
+  //   setState(() {
+  //     questionHistoryData = data["question_history"];
+  //     rankingData = data["ranking"];
+  //   });
+  // }
+
   @override
   void initState() {
     super.initState();
-    getData();
+    getUser();
+    // postStart();
+    // postQuestion();
+    // postAnswer();
+    // postAnswer();
+    // postResult();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   flutter_tindercard: ^0.2.0
+  http: ^0.13.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
fixed #2 
API連携処理のサンプルを実装しました。
HTTP通信のために[http](https://pub.dev/packages/http/install) を導入しています。

サンプルとして受け取ったAPIはリストに格納して保持できるようにしています。
動作確認のためWidget部分をここで実装していますが、api.dartはメソッドのみを持てるようにしたいです。

バックエンドのエンドポイントの仕様は下記を参照しています。
https://docs.google.com/spreadsheets/d/1vSFj8MW07QFGrukhKsckCQtRT4PEgpBXsOGtH_o7MYM/edit#gid=0