### PR TITLE
Fix 21 return answer to bf

### DIFF
--- a/lib/judgeProcessPage.dart
+++ b/lib/judgeProcessPage.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:hello_world/questiondata.dart';
-import 'package:hello_world/tinderCards.dart';
 import 'package:hello_world/model/api.dart';
-import 'dart:async';
+import 'package:hello_world/tinderCards.dart';
 
 class JudgeProcessPage extends StatefulWidget {
-
-  judgeProcessPage(){
+  judgeProcessPage() {
     //getController().stream.listen((event) {print("イベント");});
   }
 
@@ -21,14 +18,19 @@ class _JudgeProcessPageState extends State<JudgeProcessPage> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
-          FloatingActionButton(onPressed: () {},
+          FloatingActionButton(
+            onPressed: () {},
             child: const Icon(Icons.thumb_down_alt_outlined),
-            backgroundColor: Colors.deepOrange,),
-          FloatingActionButton(onPressed: () {
-            API_Init();
-          },
+            backgroundColor: Colors.deepOrange,
+          ),
+          FloatingActionButton(
+            onPressed: () {
+              API_Init();
+              GAME_ID_INIT();
+            },
             child: const Icon(Icons.thumb_up_alt_outlined),
-            backgroundColor: Colors.lightGreen,),
+            backgroundColor: Colors.lightGreen,
+          ),
         ],
       ),
     );
@@ -36,9 +38,11 @@ class _JudgeProcessPageState extends State<JudgeProcessPage> {
 
   Widget _dummyCard() {
     //本命のwidgetが実装されるまでの措置
-    return Card(child: Padding(
+    return Card(
+        child: Padding(
       padding: const EdgeInsets.all(100.0),
-      child: Center(child: Column(
+      child: Center(
+          child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           const Text("Q1"),
@@ -51,16 +55,17 @@ class _JudgeProcessPageState extends State<JudgeProcessPage> {
   }
 
   @override
-  void initState(){
-    getController().stream.listen((event) {setState(() {});});
+  void initState() {
+    getController().stream.listen((event) {
+      setState(() {});
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text("診断中")),
-      body:
-      Column(
+      body: Column(
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
@@ -70,7 +75,6 @@ class _JudgeProcessPageState extends State<JudgeProcessPage> {
           buttonsMenu()
         ],
       ),
-
     );
   }
 }

--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -4,8 +4,6 @@ import 'dart:convert';
 import 'package:hello_world/questiondata.dart';
 import 'package:http/http.dart' as http;
 
-Map data = new Map();
-List userData = [];
 String startData = "0";
 
 final controller = StreamController<bool>.broadcast();
@@ -21,6 +19,7 @@ void getGameId() async {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*'
   });
+  Map data = new Map();
   data = json.decode(response.body);
   String gameId = data["game_id"];
   // print("gameId:");
@@ -33,8 +32,10 @@ void getGameId() async {
 Future getQuestion() async {
   var url = Uri.parse('https://reqres.in/api/users?page=1');
   http.Response response = await http.get(url);
-  data = json.decode(response.body); //json->Mapオブジェクトに格納
 
+  Map data = new Map();
+  List userData = [];
+  data = json.decode(response.body); //json->Mapオブジェクトに格納
   userData = data["data"];
   for (var i = 0; i < userData.length; i++) {
     int id = userData[i]["id"];
@@ -58,7 +59,9 @@ Future setQuestion() async {
 
   String? gameId = QuestionData.gameId;
 
-  http.Response response;
+  http.Response response = await http.get(url);
+
+  Map data = new Map();
 
   for (int i = 0; i < QuestionData().getlength(); i++) {
     String body = json.encode({
@@ -81,14 +84,41 @@ Future getResult() async {
   Map<String, String> headers = {'content-type': 'application/json'};
 
   String? gameId = QuestionData.gameId;
-  http.Response response;
 
+  http.Response response = await http.get(url);
+
+  Map data = new Map();
+  for (int i = 0; i < QuestionData().getlength(); i++) {
+    String body = json.encode({
+      "game_id": gameId.toString(),
+    });
+    response = await http.post(url, headers: headers, body: body);
+
+    /* TODO: json.decodeで発生する下記のエラーの修正
+    E/flutter (11490): [ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: FormatException: Unexpected character (at character 1)
+    E/flutter (11490): <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+    E/flutter (11490): ^
+     */
+    // data = json.decode(response.body);
+    // String circleName = data["name"];
+    // int ranking = i;
+    // ここでresultをQuestionDataに格納し
+    // ResultData().set(i, Result(ranking, circleName));
+  }
+
+  // endを呼ぶ
+  postGameEnd();
+}
+
+void postGameEnd() async {
+  var url = Uri.parse('https://quiet-eyrie-21766.herokuapp.com/end');
+  Map<String, String> headers = {'content-type': 'application/json'};
+
+  String? gameId = QuestionData.gameId;
+  http.Response response;
   String body = json.encode({"game_id": gameId});
   response = await http.post(url, headers: headers, body: body);
-  data = json.decode(response.body);
-  String circleName = data["name"];
-  // ここでresultをQuestionDataに格納し
-  // /endを呼ぶ
+  print(response);
 }
 
 //@override

--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -23,9 +23,10 @@ void getGameId() async {
   });
   data = json.decode(response.body);
   String gameId = data["game_id"];
-  print("gameId:");
-  print(gameId);
+  // print("gameId:");
+  // print(gameId);
   // TODO:gameIdをreturnする
+  QuestionData.gameId = gameId;
 }
 
 // モックAPIからカードに描画する情報を取得する
@@ -40,8 +41,8 @@ Future getQuestion() async {
     String sentence = userData[i]["email"];
     String image = userData[i]["avatar"];
     QuestionData().set(i, Question(id, sentence, image));
-    print(id);
-    print(sentence + image);
+    // print(id);
+    // print(sentence + image);
   }
   //Map->Listに必要な情報だけ格納
   controller.sink.add(true);
@@ -52,16 +53,42 @@ Future setQuestion() async {
   var url =
       Uri.parse('https://quiet-eyrie-21766.herokuapp.com/question/answer');
   Map<String, String> headers = {'content-type': 'application/json'};
+
   // TODO:ここでgame_idとquestion_idとresultはquestiondataのAnswerを参照したい
-  String body = json.encode({
-    "game_id": "2745e04c-4e5c-4d52-a25a-ff8a48055e1a",
-    "question_id": "1",
-    "result": true
-  });
-  http.Response response = await http.post(url, headers: headers, body: body);
+
+  String? gameId = QuestionData.gameId;
+
+  http.Response response;
+
+  for (int i = 0; i < QuestionData().getlength(); i++) {
+    String body = json.encode({
+      "game_id": gameId,
+      "question_id": i.toString(),
+      "result": QuestionData().GetAnswer(i).toString(),
+    });
+    print(body);
+    response = await http.post(url, headers: headers, body: body);
+    data = json.decode(response.body);
+    String messageData = data["message"];
+    print(messageData);
+  }
+
+  getResult();
+}
+
+Future getResult() async {
+  var url = Uri.parse('https://quiet-eyrie-21766.herokuapp.com/result');
+  Map<String, String> headers = {'content-type': 'application/json'};
+
+  String? gameId = QuestionData.gameId;
+  http.Response response;
+
+  String body = json.encode({"game_id": gameId});
+  response = await http.post(url, headers: headers, body: body);
   data = json.decode(response.body);
-  String messageData = data["data"];
-  print(messageData);
+  String circleName = data["name"];
+  // ここでresultをQuestionDataに格納し
+  // /endを呼ぶ
 }
 
 //@override
@@ -71,5 +98,8 @@ void API_Init() async {
 
 void GAME_ID_INIT() async {
   getGameId();
+}
+
+void GAME_END() async {
   setQuestion();
 }

--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -17,8 +17,10 @@ StreamController<bool> getController() {
 // スタート時にPOSTでゲームIDを取得する
 void getGameId() async {
   var url = Uri.parse('https://circlejudgebackend.herokuapp.com/start');
-  final response =
-      await http.post(url, headers: {'Content-Type': 'application/json'});
+  final response = await http.post(url, headers: {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*'
+  });
   data = json.decode(response.body);
   String gameId = data["game_id"];
   print("gameId:");
@@ -52,8 +54,8 @@ Future setQuestion() async {
   Map<String, String> headers = {'content-type': 'application/json'};
   // TODO:ここでgame_idとquestion_idとresultはquestiondataのAnswerを参照したい
   String body = json.encode({
-    "game_id": "8141080a-792a-4b17-ace3-5b5b7927277f",
-    "question_id": 1,
+    "game_id": "2745e04c-4e5c-4d52-a25a-ff8a48055e1a",
+    "question_id": "1",
     "result": true
   });
   http.Response response = await http.post(url, headers: headers, body: body);
@@ -69,4 +71,5 @@ void API_Init() async {
 
 void GAME_ID_INIT() async {
   getGameId();
+  setQuestion();
 }

--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -1,63 +1,72 @@
-import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:hello_world/questiondata.dart';
+import 'package:http/http.dart' as http;
 
 Map data = new Map();
 List userData = [];
 String startData = "0";
-final controller = StreamController<bool>.broadcast();
-  // ゲームスタート時に必要なゲームIDを受け取る
-  // Future postStart() async {
-  //   var url = Uri.parse('https://circle-judge-backend.herokuapp.com/start');
-  //   http.Response response = await http.get(url);
-  //   data = json.decode(response.body);
-  //   setState(() {
-  //     startData = data["message"];
-  //   });
-  // }
 
-StreamController<bool> getController (){
+final controller = StreamController<bool>.broadcast();
+
+StreamController<bool> getController() {
   return controller;
 }
-  // モックAPI
-  Future getQuestion() async {
-    var url = Uri.parse('https://reqres.in/api/users?page=1');
-    http.Response response = await http.get(url);
-    data = json.decode(response.body); //json->Mapオブジェクトに格納
 
-    userData = data["data"];
-    for (var i = 0; i < userData.length; i++) {
-      int id = userData[i]["id"];
-      String sentence = userData[i]["email"];
-      String image = userData[i]["avatar"];
-      QuestionData().set(i, Question(id, sentence, image));
-      print(id);
-      print(sentence+image);
-    }
-    //Map->Listに必要な情報だけ格納
-    controller.sink.add(true);
+// スタート時にPOSTでゲームIDを取得する
+void getGameId() async {
+  var url = Uri.parse('https://circlejudgebackend.herokuapp.com/start');
+  final response =
+      await http.post(url, headers: {'Content-Type': 'application/json'});
+  data = json.decode(response.body);
+  String gameId = data["game_id"];
+  print("gameId:");
+  print(gameId);
+  // TODO:gameIdをreturnする
+}
+
+// モックAPIからカードに描画する情報を取得する
+Future getQuestion() async {
+  var url = Uri.parse('https://reqres.in/api/users?page=1');
+  http.Response response = await http.get(url);
+  data = json.decode(response.body); //json->Mapオブジェクトに格納
+
+  userData = data["data"];
+  for (var i = 0; i < userData.length; i++) {
+    int id = userData[i]["id"];
+    String sentence = userData[i]["email"];
+    String image = userData[i]["avatar"];
+    QuestionData().set(i, Question(id, sentence, image));
+    print(id);
+    print(sentence + image);
   }
+  //Map->Listに必要な情報だけ格納
+  controller.sink.add(true);
+}
 
+// バックエンドにPOSTで回答を返却する
 Future setQuestion() async {
-  var url = Uri.parse('https://circlejudgebackend.herokuapp.com/question/answer');
+  var url =
+      Uri.parse('https://circlejudgebackend.herokuapp.com/question/answer');
   Map<String, String> headers = {'content-type': 'application/json'};
-  String body = json.encode ({"game_id":"8141080a-792a-4b17-ace3-5b5b7927277f", "question_id":1,"result":true});
-  http.Response response = await http.post(url, headers: headers, body:body);
+  // TODO:ここでgame_idとquestion_idとresultはquestiondataのAnswerを参照したい
+  String body = json.encode({
+    "game_id": "8141080a-792a-4b17-ace3-5b5b7927277f",
+    "question_id": 1,
+    "result": true
+  });
+  http.Response response = await http.post(url, headers: headers, body: body);
   data = json.decode(response.body);
   String messageData = data["data"];
   print(messageData);
 }
 
-  //@override
-  void API_Init() async{
-    //super.initState();
-    await getQuestion();
-    await setQuestion();
-    // postStart();
-    // postQuestion();
-    // postAnswer();
-    // postAnswer();
-    // postResult();
-  }
+//@override
+void API_Init() async {
+  await getQuestion();
+}
+
+void GAME_ID_INIT() async {
+  getGameId();
+}

--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -17,10 +17,10 @@ final controller = StreamController<bool>.broadcast();
   //     startData = data["message"];
   //   });
   // }
+
 StreamController<bool> getController (){
   return controller;
 }
-
   // モックAPI
   Future getQuestion() async {
     var url = Uri.parse('https://reqres.in/api/users?page=1');
@@ -40,38 +40,21 @@ StreamController<bool> getController (){
     controller.sink.add(true);
   }
 
-  // Future postQuestion() async {
-  //   var url = Uri.parse('https://circle-judge-backend.herokuapp.com/question');
-  //   http.Response response = await http.get(url);
-  //   data = json.decode(response.body);
-  //   setState(() {
-  //     questionData = data["data"];
-  //   });
-  // }
-
-  // Future postAnswer() async {
-  //   var url = Uri.parse('https://circle-judge-backend.herokuapp.com/question/answer');
-  //   http.Response response = await http.get(url);
-  //   data = json.decode(response.body);
-  //   setState(() {
-  //     answerData = data["message"];
-  //   });
-  // }
-
-  // Future postResult() async {
-  //   var url = Uri.parse('https://circle-judge-backend.herokuapp.com/result');
-  //   http.Response response = await http.get(url);
-  //   data = json.decode(response.body);
-  //   setState(() {
-  //     questionHistoryData = data["question_history"];
-  //     rankingData = data["ranking"];
-  //   });
-  // }
+Future setQuestion() async {
+  var url = Uri.parse('https://circlejudgebackend.herokuapp.com/question/answer');
+  Map<String, String> headers = {'content-type': 'application/json'};
+  String body = json.encode ({"game_id":"8141080a-792a-4b17-ace3-5b5b7927277f", "question_id":1,"result":true});
+  http.Response response = await http.post(url, headers: headers, body:body);
+  data = json.decode(response.body);
+  String messageData = data["data"];
+  print(messageData);
+}
 
   //@override
   void API_Init() async{
     //super.initState();
     await getQuestion();
+    await setQuestion();
     // postStart();
     // postQuestion();
     // postAnswer();

--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -16,7 +16,7 @@ StreamController<bool> getController() {
 
 // スタート時にPOSTでゲームIDを取得する
 void getGameId() async {
-  var url = Uri.parse('https://circlejudgebackend.herokuapp.com/start');
+  var url = Uri.parse('https://quiet-eyrie-21766.herokuapp.com/start');
   final response = await http.post(url, headers: {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*'
@@ -50,7 +50,7 @@ Future getQuestion() async {
 // バックエンドにPOSTで回答を返却する
 Future setQuestion() async {
   var url =
-      Uri.parse('https://circlejudgebackend.herokuapp.com/question/answer');
+      Uri.parse('https://quiet-eyrie-21766.herokuapp.com/question/answer');
   Map<String, String> headers = {'content-type': 'application/json'};
   // TODO:ここでgame_idとquestion_idとresultはquestiondataのAnswerを参照したい
   String body = json.encode({

--- a/lib/questiondata.dart
+++ b/lib/questiondata.dart
@@ -1,18 +1,16 @@
-import 'package:flutter/material.dart';
-
 //Questionの情報を持つクラス
-class Question{
+class Question {
   int question_number;
   String question_sentence;
   String question_image;
   bool? answer;
-  Question(this.question_number,this.question_sentence,this.question_image){}
+  Question(this.question_number, this.question_sentence, this.question_image) {}
 }
 
 //Singletonでデータをキャッシュする
-class QuestionData{
+class QuestionData {
   static final Map<int, Question> _item = <int, Question>{};
-  static final QuestionData _cache=QuestionData._internal();
+  static final QuestionData _cache = QuestionData._internal();
   static String? gameId;
 
   factory QuestionData() {
@@ -22,27 +20,34 @@ class QuestionData{
   set(int key, Question value) => _item[key] = value;
   get(int key) => _item[key];
   //質問数を返す
-  getlength()=>_item.length;
+  getlength() => _item.length;
   //質問文を返す
-  GetQuestion(int num){
-    Question question=QuestionData().get(num);
+  GetQuestion(int num) {
+    Question question = QuestionData().get(num);
     //String tmp=Q.question_sentence;
     return question.question_sentence;
   }
+
   //質問画像を返す
-  GetImage(int num){
-    Question question=QuestionData().get(num);
+  GetImage(int num) {
+    Question question = QuestionData().get(num);
     //String tmp=Q.question_sentence;
     return question.question_image;
   }
+
   //回答を保存する
-  SetAnswer(bool answer,int num){
-    Question question=QuestionData().get(num);
-    question.answer=answer;
+  SetAnswer(bool answer, int num) {
+    Question question = QuestionData().get(num);
+    question.answer = answer;
   }
+
   //指定された問題番号の回答を返す
-  GetAnswer(int num){
-    Question question=QuestionData().get(num);
-    return question.answer;
+  GetAnswer(int num) {
+    Question question = QuestionData().get(num);
+    if (question.answer == true) {
+      return 3;
+    } else {
+      return 2;
+    }
   }
 }

--- a/lib/questiondata.dart
+++ b/lib/questiondata.dart
@@ -45,9 +45,9 @@ class QuestionData {
   GetAnswer(int num) {
     Question question = QuestionData().get(num);
     if (question.answer == true) {
-      return 3;
+      return 0;
     } else {
-      return 2;
+      return 1;
     }
   }
 }

--- a/lib/questiondata.dart
+++ b/lib/questiondata.dart
@@ -5,7 +5,7 @@ class Question{
   int question_number;
   String question_sentence;
   String question_image;
-  String? Answer;
+  bool? answer;
   Question(this.question_number,this.question_sentence,this.question_image){}
 }
 
@@ -13,7 +13,7 @@ class Question{
 class QuestionData{
   static final Map<int, Question> _item = <int, Question>{};
   static final QuestionData _cache=QuestionData._internal();
-  static int? gameId;
+  static String? gameId;
 
   factory QuestionData() {
     return _cache;
@@ -35,20 +35,14 @@ class QuestionData{
     //String tmp=Q.question_sentence;
     return question.question_image;
   }
-  //answer 1:Yes 0:Even -1:No
-  SetAnswer(int answer,int num){
+  //回答を保存する
+  SetAnswer(bool answer,int num){
     Question question=QuestionData().get(num);
-    if(answer==1){
-      question.Answer="Yes";
-    }
-    else if(answer==-1){
-      question.Answer="No";
-    }
-    else if(answer==0){
-      question.Answer="Even";
-    }
-    else{
-      print("回答が不正です");
-    }
+    question.answer=answer;
+  }
+  //指定された問題番号の回答を返す
+  GetAnswer(int num){
+    Question question=QuestionData().get(num);
+    return question.answer;
   }
 }

--- a/lib/resultdata.dart
+++ b/lib/resultdata.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+//Questionの情報を持つクラス
+class Result{
+  int circlerank;
+  String circlename;
+  Result(this.circlerank,this.circlename){}
+}
+
+//Singletonでデータをキャッシュする
+class ResultData{
+  static final Map<int, Result> _item = <int, Result>{};
+  static final ResultData _cache=ResultData._internal();
+  static int? gameId;
+
+  factory ResultData() {
+    return _cache;
+  }
+  ResultData._internal();
+  set(int key, Result value) => _item[key] = value;
+  get(int key) => _item[key];
+/*
+  //質問数を返す
+  getlength()=>_item.length;
+  //質問文を返す
+  GetQuestion(int num){
+    Question question=QuestionData().get(num);
+    //String tmp=Q.question_sentence;
+    return question.question_sentence;
+  }
+  //質問画像を返す
+  GetImage(int num){
+    Question question=QuestionData().get(num);
+    //String tmp=Q.question_sentence;
+    return question.question_image;
+  }
+  //answer 1:Yes 0:Even -1:No
+  SetAnswer(int answer,int num){
+    Question question=QuestionData().get(num);
+    if(answer==1){
+      question.Answer="Yes";
+    }
+    else if(answer==-1){
+      question.Answer="No";
+    }
+    else if(answer==0){
+      question.Answer="Even";
+    }
+    else{
+      print("回答が不正です");
+    }
+  }
+  */
+}

--- a/lib/tinderCards.dart
+++ b/lib/tinderCards.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_tindercard/flutter_tindercard.dart';
+import 'package:hello_world/model/api.dart';
 import 'package:hello_world/questiondata.dart';
 
 class TinderCards extends StatelessWidget {
@@ -15,63 +16,54 @@ class TinderCards extends StatelessWidget {
   Widget build(BuildContext context) {
     CardController controller;
     return Container(
-      height: MediaQuery
-          .of(context)
-          .size
-          .height * 0.6,
+      height: MediaQuery.of(context).size.height * 0.6,
       child: TinderSwapCard(
         swipeUp: true,
         swipeDown: true,
         orientation: AmassOrientation.BOTTOM,
-        totalNum:QuestionData().getlength(),
+        totalNum: QuestionData().getlength(),
         stackNum: 3,
         swipeEdge: 4.0,
-        maxWidth: MediaQuery
-            .of(context)
-            .size
-            .width * 0.9,
-        maxHeight: MediaQuery
-            .of(context)
-            .size
-            .width * 0.9,
-        minWidth: MediaQuery
-            .of(context)
-            .size
-            .width * 0.8,
-        minHeight: MediaQuery
-            .of(context)
-            .size
-            .width * 0.8,
+        maxWidth: MediaQuery.of(context).size.width * 0.9,
+        maxHeight: MediaQuery.of(context).size.width * 0.9,
+        minWidth: MediaQuery.of(context).size.width * 0.8,
+        minHeight: MediaQuery.of(context).size.width * 0.8,
         cardBuilder: (context, index) =>
-        //StreamBuilder<bool>(
-          //stream:controller.st
+            //StreamBuilder<bool>(
+            //stream:controller.st
             Column(
-              children:[
-                Card(
-                  color:Colors.grey,
-                    child:
-                          Column(
-                            children: [
-                              Text(QuestionData().GetQuestion(index),
-                                style: TextStyle(fontSize: 35),),
-                              Image.network(QuestionData().GetImage(index),fit:BoxFit.contain/*: 240, */,height: 230,),
-                            ],)
-                )
-              ],
-            ),
+          children: [
+            Card(
+                color: Colors.grey,
+                child: Column(
+                  children: [
+                    Text(
+                      QuestionData().GetQuestion(index),
+                      style: TextStyle(fontSize: 35),
+                    ),
+                    Image.network(
+                      QuestionData().GetImage(index),
+                      fit: BoxFit.contain /*: 240, */,
+                      height: 230,
+                    ),
+                  ],
+                ))
+          ],
+        ),
         cardController: controller = CardController(),
-        swipeCompleteCallback:
-            (CardSwipeOrientation orientation, int index) {
+        swipeCompleteCallback: (CardSwipeOrientation orientation, int index) {
           print(orientation.name);
           print(index);
-          if(orientation.name=="RIGHT"){
+          if (orientation.name == "RIGHT") {
             QuestionData().SetAnswer(true, index);
-          }
-          else if(orientation.name=="LEFT"){
+          } else if (orientation.name == "LEFT") {
             QuestionData().SetAnswer(false, index);
           }
+          if (index + 1 == QuestionData().getlength()) {
+            GAME_END();
+          }
         },
-        ),
+      ),
       //),
     );
   }

--- a/lib/tinderCards.dart
+++ b/lib/tinderCards.dart
@@ -59,6 +59,18 @@ class TinderCards extends StatelessWidget {
                 )
               ],
             ),
+        cardController: controller = CardController(),
+        swipeCompleteCallback:
+            (CardSwipeOrientation orientation, int index) {
+          print(orientation.name);
+          print(index);
+          if(orientation.name=="RIGHT"){
+            QuestionData().SetAnswer(true, index);
+          }
+          else if(orientation.name=="LEFT"){
+            QuestionData().SetAnswer(false, index);
+          }
+        },
         ),
       //),
     );


### PR DESCRIPTION
fixed #21 
## やったこと

- 下記の処理を結合
ゲームスタート時にバックエンド`/start`からゲームIDを取得する  
バックエンド`/question/answer`に回答結果`YES/NO`を返却する  
バックエンド`/result`からサークル名を取得する  
ゲーム終了時にバックエンド`/end`にゲームIDを返却する  
  
## やらないこと

無し

## できるようになること（ユーザ目線）

無し  

## できなくなること（ユーザ目線）

無し

## 動作確認

Webビルド(chrome/IE)とWindows(デスクトップ)で行いました

## その他

- [バックエンドのAPIエンドポイント](https://circlejudgebackend.herokuapp.com/)
- [API定義書](https://docs.google.com/spreadsheets/d/1vSFj8MW07QFGrukhKsckCQtRT4PEgpBXsOGtH_o7MYM/edit?usp=sharing)

chromeビルドだと下記で怒られます（未解決）が、[CORS}(https://developer.mozilla.org/ja/docs/Web/HTTP/CORS)によるエラーのためエミュレータのビルドでは問題ないことを確認しています。
```
Error: XMLHttpRequest error.
```
