### PR TITLE
回答をquestiondataに保存する処理の追加

### DIFF
--- a/lib/questiondata.dart
+++ b/lib/questiondata.dart
@@ -5,7 +5,7 @@ class Question{
   int question_number;
   String question_sentence;
   String question_image;
-  String? Answer;
+  bool? answer;
   Question(this.question_number,this.question_sentence,this.question_image){}
 }
 
@@ -13,7 +13,7 @@ class Question{
 class QuestionData{
   static final Map<int, Question> _item = <int, Question>{};
   static final QuestionData _cache=QuestionData._internal();
-  static int? gameId;
+  static String? gameId;
 
   factory QuestionData() {
     return _cache;
@@ -35,20 +35,14 @@ class QuestionData{
     //String tmp=Q.question_sentence;
     return question.question_image;
   }
-  //answer 1:Yes 0:Even -1:No
-  SetAnswer(int answer,int num){
+  //回答を保存する
+  SetAnswer(bool answer,int num){
     Question question=QuestionData().get(num);
-    if(answer==1){
-      question.Answer="Yes";
-    }
-    else if(answer==-1){
-      question.Answer="No";
-    }
-    else if(answer==0){
-      question.Answer="Even";
-    }
-    else{
-      print("回答が不正です");
-    }
+    question.answer=answer;
+  }
+  //指定された問題番号の回答を返す
+  GetAnswer(int num){
+    Question question=QuestionData().get(num);
+    return question.answer;
   }
 }

--- a/lib/tinderCards.dart
+++ b/lib/tinderCards.dart
@@ -59,6 +59,18 @@ class TinderCards extends StatelessWidget {
                 )
               ],
             ),
+        cardController: controller = CardController(),
+        swipeCompleteCallback:
+            (CardSwipeOrientation orientation, int index) {
+          print(orientation.name);
+          print(index);
+          if(orientation.name=="RIGHT"){
+            QuestionData().SetAnswer(true, index);
+          }
+          else if(orientation.name=="LEFT"){
+            QuestionData().SetAnswer(false, index);
+          }
+        },
         ),
       //),
     );


### PR DESCRIPTION
fixed #21 #8 
## やったこと

・Questiondataの持つgameIDをString型に変更
・カードスワイプの方向を取ってQuestiondataにbool型の回答データとして保存する処理の実装
・Questiondataの中に指定された番号の質問の回答を返す関数を追加

## やらないこと

api.dartとの結合

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

エミュレータ上での動作確認

## その他

現状ではバックエンドの質問番号は1から始まるのに対して、TinderCardの番号管理が配列での管理である関係上0から始まっており、回答の保存されている問題番号が一つずれている可能性がある。どこかで補正、あるいは修正が必要。
