### PR TITLE
Fix 28 sence transition

### DIFF
--- a/lib/judgeProcessPage.dart
+++ b/lib/judgeProcessPage.dart
@@ -26,10 +26,7 @@ class _JudgeProcessPageState extends State<JudgeProcessPage> {
           ),
           FloatingActionButton(
             heroTag: "bad",
-            onPressed: () {
-              GAME_ID_INIT();
-              API_Init();
-            },
+            onPressed: () {},
             child: const Icon(Icons.thumb_up_alt_outlined),
             backgroundColor: Colors.lightGreen,
           ),

--- a/lib/judgeProcessPage.dart
+++ b/lib/judgeProcessPage.dart
@@ -19,13 +19,14 @@ class _JudgeProcessPageState extends State<JudgeProcessPage> {
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           FloatingActionButton(
+            heroTag: "good",
             onPressed: () {},
             child: const Icon(Icons.thumb_down_alt_outlined),
             backgroundColor: Colors.deepOrange,
           ),
           FloatingActionButton(
+            heroTag: "bad",
             onPressed: () {
-              print("bottunpushed");
               GAME_ID_INIT();
               API_Init();
             },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,8 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_tindercard/flutter_tindercard.dart';
 import 'package:hello_world/judgeProcessPage.dart';
+import 'package:hello_world/resultPage.dart';
+import 'package:hello_world/titlePage.dart';
 
 void main() => runApp(MyApp());
 
@@ -15,7 +15,12 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: JudgeProcessPage(),//ExampleHomePage(),
+      // home: JudgeProcessPage(),//ExampleHomePage(),
+      home: TitlePage(),
+      routes: <String, WidgetBuilder>{
+        '/judge': (BuildContext context) => new JudgeProcessPage(),
+        '/result': (BuildContext context) => new ResultPage(),
+      },
     );
   }
 }
@@ -39,18 +44,17 @@ class _ExampleHomePageState extends State<ExampleHomePage>
     "assets/sample2.png",
     "assets/sample3.png",
     */
-
   ];
 
   @override
   Widget build(BuildContext context) {
     CardController controller; //Use this to trigger swap.
 
-    return  Scaffold(
-      body:  Center(
+    return Scaffold(
+      body: Center(
         child: Container(
           height: MediaQuery.of(context).size.height * 0.6,
-          child:  TinderSwapCard(
+          child: TinderSwapCard(
             swipeUp: true,
             swipeDown: true,
             orientation: AmassOrientation.BOTTOM,
@@ -61,9 +65,12 @@ class _ExampleHomePageState extends State<ExampleHomePage>
             maxHeight: MediaQuery.of(context).size.width * 0.9,
             minWidth: MediaQuery.of(context).size.width * 0.8,
             minHeight: MediaQuery.of(context).size.width * 0.8,
-            cardBuilder: (context, index) => Card(child:Image.network(welcomeImages[index],)
-            //Card(child : Image.asset('${welcomeImages[index]}')
-            ),
+            cardBuilder: (context, index) => Card(
+                child: Image.network(
+              welcomeImages[index],
+            )
+                //Card(child : Image.asset('${welcomeImages[index]}')
+                ),
             cardController: controller = CardController(),
             /*swipeUpdateCallback:
                 (DragUpdateDetails details, Alignment align) {
@@ -75,13 +82,10 @@ class _ExampleHomePageState extends State<ExampleHomePage>
               }
             },*/
             swipeCompleteCallback:
-                (CardSwipeOrientation orientation, int index) {
-
-            },
+                (CardSwipeOrientation orientation, int index) {},
           ),
         ),
       ),
     );
   }
 }
-

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,12 +18,13 @@ class MyApp extends StatelessWidget {
       // home: JudgeProcessPage(),//ExampleHomePage(),
       home: TitlePage(),
       routes: <String, WidgetBuilder>{
+        '/title': (BuildContext context) => new TitlePage(),
         '/judge': (BuildContext context) => new JudgeProcessPage(),
         '/result': (BuildContext context) => new ResultPage(),
       },
     );
   }
-}
+}r
 
 class ExampleHomePage extends StatefulWidget {
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
       },
     );
   }
-}r
+}
 
 class ExampleHomePage extends StatefulWidget {
   @override

--- a/lib/resultpage.dart
+++ b/lib/resultpage.dart
@@ -178,7 +178,10 @@ class ResultPage extends StatelessWidget {
                       child: const Icon(Icons.share),
                     ),
                     ElevatedButton(
-                        onPressed: () {}, child: const Text('タイトルへ')),
+                        onPressed: () {
+                          Navigator.of(context).pushNamed("/title");
+                        },
+                        child: const Text('タイトルへ')),
                   ],
                 ),
               ),

--- a/lib/tinderCards.dart
+++ b/lib/tinderCards.dart
@@ -59,7 +59,9 @@ class TinderCards extends StatelessWidget {
           } else if (orientation.name == "LEFT") {
             QuestionData().SetAnswer(false, index);
           }
-          if (index + 1 == QuestionData().getlength()&&orientation.name!="RECOVER") {
+          if (index + 1 == QuestionData().getlength() &&
+              orientation.name != "RECOVER") {
+            Navigator.of(context).pushNamed("/result");
             GAME_END();
           }
         },

--- a/lib/titlePage.dart
+++ b/lib/titlePage.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hello_world/model/api.dart';
 
 class TitlePage extends StatelessWidget {
   Widget Title() {
@@ -13,10 +14,7 @@ class TitlePage extends StatelessWidget {
 
   Widget StartButton(BuildContext context) {
     return ElevatedButton(
-        onPressed: () {
-          // Navigator.of(context).pushNamed("/judge");
-          print("aaa");
-        },
+        onPressed: () {},
         child: Container(
           padding: EdgeInsets.symmetric(),
           child: Text("始める"),
@@ -43,7 +41,8 @@ class TitlePage extends StatelessWidget {
             Spacer(flex: 1),
             ElevatedButton(
                 onPressed: () {
-                  print("aaa");
+                  GAME_ID_INIT();
+                  API_Init();
                   Navigator.of(context).pushNamed("/judge");
                 },
                 child: Text("始める")),

--- a/lib/titlePage.dart
+++ b/lib/titlePage.dart
@@ -1,44 +1,56 @@
 import 'package:flutter/material.dart';
 
 class TitlePage extends StatelessWidget {
-  Widget Title(){
+  Widget Title() {
     return Container(
       padding: EdgeInsets.all(10),
-      child: Text("サークル診断アプリ",style: TextStyle(fontSize: 40),),
+      child: Text(
+        "サークル診断アプリ",
+        style: TextStyle(fontSize: 40),
+      ),
     );
   }
-  Widget StartButton(){
+
+  Widget StartButton(BuildContext context) {
     return ElevatedButton(
-        onPressed: (){},
+        onPressed: () {
+          // Navigator.of(context).pushNamed("/judge");
+          print("aaa");
+        },
         child: Container(
           padding: EdgeInsets.symmetric(),
           child: Text("始める"),
-        )
-    );
+        ));
   }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Container(
-        decoration: BoxDecoration(
+        body: Container(
+      decoration: BoxDecoration(
           image: DecorationImage(
-            image: AssetImage('wallpaper.jpeg'),
-            fit:BoxFit.cover,
-          )
+        image: AssetImage('wallpaper.jpeg'),
+        fit: BoxFit.cover,
+      )),
+      child: Center(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Spacer(
+              flex: 1,
+            ),
+            Title(),
+            Spacer(flex: 1),
+            ElevatedButton(
+                onPressed: () {
+                  print("aaa");
+                  Navigator.of(context).pushNamed("/judge");
+                },
+                child: Text("始める")),
+            Spacer(flex: 3),
+          ],
         ),
-        child: Center(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Spacer(flex: 1,),
-              Title(),
-              Spacer(flex:1),
-              ElevatedButton(onPressed:(){},child: Text("始める")),
-              Spacer(flex:3),
-            ],
-          ),
-        ),
-      )
-    );
+      ),
+    ));
   }
 }

--- a/lib/titlePage.dart
+++ b/lib/titlePage.dart
@@ -43,6 +43,7 @@ class TitlePage extends StatelessWidget {
                 onPressed: () {
                   GAME_ID_INIT();
                   API_Init();
+                  // CircularProgressIndicator();
                   Navigator.of(context).pushNamed("/judge");
                 },
                 child: Text("始める")),


### PR DESCRIPTION
fixed #28
## やったこと

- タイトル画面→診断画面におけるページ遷移の実装
  - https://github.com/618knot/circle_judge/commit/a331300903a3bcbd26ebd7770e827def7a031975
  - https://github.com/618knot/circle_judge/commit/db5c7f1b45ec318947b96657a869dde1d21850a7  
- 診断画面→リザルト画面におけるページ遷移の実装  
  - https://github.com/618knot/circle_judge/pull/43/commits/d99b5e08e87c55f7d527c4af10c981cb3a32af9e
- リザルト画面→タイトル画面におけるページ遷移の実装  
  - https://github.com/618knot/circle_judge/pull/43/commits/f603f6bb3339e753a3ded62ec69149462072e56b
- APIを呼び出すタイミングをトップページから診断ページへの遷移時に修正  
  - https://github.com/618knot/circle_judge/pull/43/commits/b3c595f776e5297630bf767ec82cb2a3a9e920eb
- FloatingActionButtonの改修 
  - https://github.com/618knot/circle_judge/commit/9b4bb7d638d655fa75bdfac2ce7e6188d876c89b  

## やらないこと

- なし

## できるようになること（ユーザ目線）

- なし

## できなくなること（ユーザ目線）

- なし

## 動作確認

- エミュレータでの動作確認

## その他
[参考]
- FloatingActionButtonは複数並べる場合heroTagで区別する必要あり  

https://api.flutter.dev/flutter/material/FloatingActionButton-class.html