### PR TITLE
fix releaseビルドのAPI通信における権限を付与

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.hello_world">
+    <uses-permission android:name="android.permission.INTERNET" />
    <application
         android:label="hello_world"
         android:name="${applicationName}"

--- a/lib/tinderCards.dart
+++ b/lib/tinderCards.dart
@@ -44,7 +44,7 @@ class TinderCards extends StatelessWidget {
                     Image.network(
                       QuestionData().GetImage(index),
                       fit: BoxFit.contain /*: 240, */,
-                      height: 230,
+                      height: 170,
                     ),
                   ],
                 ))


### PR DESCRIPTION
releaseビルドではAPIとのHTTP通信に失敗していたため画面遷移ができなかった
これはネットワークに接続するための権限がないためであり、以下のように権限を`android\app\src\main\AndroidManifest.xml`に書くとうまくいった
```android\app\src\main\AndroidManifest.xml
<manifest xmlns:android="http://".....>
    <uses-permission android:name="android.permission.INTERNET" /> <!--この行を追加してください！-->
    <application android:name=......>
```
[参考]
https://qiita.com/Frog_kt/items/130c4105a0e94dc25777