### PR TITLE
通信タイミングの調整によるロードの効率化

### DIFF
--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -54,23 +54,13 @@ Future<bool> questionPost(int num) async{
 
 // モックAPIからカードに描画する情報を取得する
 Future getQuestion() async {
-  var url = Uri.parse('https://quiet-eyrie-21766.herokuapp.com/question');
-  Map<String, String> headers = {'content-type': 'application/json'};
   while (QuestionData.gameId == null) {
     await Future.delayed(Duration(microseconds: 20));
     print("wait");
   }
-  String? gameId = QuestionData.gameId;
-
-  http.Response response;
-
-  String body;
-  List<http.Response> responses;
   List<Future<bool>> future=[];
   for (int i = 1; i <= 6; i++) {
-    var tmp =questionPost(i);
     future.add(questionPost(i));
-    print("add");
   }
   var futureAll =Future.wait(future);
   futureAll.then((results) => controller.sink.add(true));

--- a/lib/model/api.dart
+++ b/lib/model/api.dart
@@ -32,6 +32,25 @@ void getGameId() async {
   // print(gameId);
   QuestionData.gameId = gameId;
 }
+Future<bool> questionPost(int num) async{
+  http.Response response;
+  var url = Uri.parse('https://quiet-eyrie-21766.herokuapp.com/question');
+  Map<String, String> headers = {'content-type': 'application/json'};
+  String body = json.encode({
+    "game_id": QuestionData.gameId,
+    "question_id": num,
+  });
+  response = await http.post(url, headers: headers, body: body);
+  List data = json.decode(response.body);
+  String image = data[0]["image_url"];
+  String sentence = data[0]["question"];
+  var jsonsentence = json.encode(sentence);
+  var utf8sentence = utf8.decode(jsonsentence.runes.toList());
+  QuestionData()
+      .set(num - 1, Question(num, utf8sentence.replaceAll('"', ''), image));
+  print("loaded");
+  return true;
+}
 
 // モックAPIからカードに描画する情報を取得する
 Future getQuestion() async {
@@ -46,23 +65,15 @@ Future getQuestion() async {
   http.Response response;
 
   String body;
-
+  List<http.Response> responses;
+  List<Future<bool>> future=[];
   for (int i = 1; i <= 6; i++) {
-    body = json.encode({
-      "game_id": gameId,
-      "question_id": i,
-    });
-    print(body);
-    response = await http.post(url, headers: headers, body: body);
-    List data = json.decode(response.body);
-    String image = data[0]["image_url"];
-    String sentence = data[0]["question"];
-    var jsonsentence = json.encode(sentence);
-    var utf8sentence = utf8.decode(jsonsentence.runes.toList());
-    QuestionData()
-        .set(i - 1, Question(i, utf8sentence.replaceAll('"', ''), image));
+    var tmp =questionPost(i);
+    future.add(questionPost(i));
+    print("add");
   }
-  controller.sink.add(true);
+  var futureAll =Future.wait(future);
+  futureAll.then((results) => controller.sink.add(true));
 }
 
 // バックエンドにPOSTで回答を返却する
@@ -155,11 +166,11 @@ Future getResult() async {
         i,
         Result(circlerank, circle_name, percent, circle_image_url,
             circle_description));
+    Resultcontroller.sink.add(true);
   }
 
   // endを呼ぶ
   postGameEnd();
-  Resultcontroller.sink.add(true);
 }
 
 void postGameEnd() async {

--- a/lib/titlePage.dart
+++ b/lib/titlePage.dart
@@ -17,6 +17,7 @@ class _State extends State<TitlePage> {
       isLoading = false;
       Navigator.of(context).pushNamed("/judge");
     });
+    GAME_ID_INIT();
   }
 
   void onPressedButton() async {
@@ -24,7 +25,7 @@ class _State extends State<TitlePage> {
       isLoading = true;
     });
 
-    GAME_ID_INIT();
+    //GAME_ID_INIT();
     API_Init();
 
     // 完了通知か問題番号を受け取りたい


### PR DESCRIPTION
1.タイトルページのInitでGAME_ID_INITを行いロード時間の短縮を図りました
2.問題のロードを並列処理に変更しました
3.診断結果がすべて帰ってきてからリザルトページを更新していたのを一つ帰ってくる毎に更新する処理に変更しました

自分の実行環境では問題のロード時間が1/3になりました
おそらく詰めれば処理自体はもう少し最適化できますが、ロード時間の短縮はこのあたりが限度ではないかと思います