### PR TITLE
診断結果ページのUI改修

### DIFF
--- a/lib/header.dart
+++ b/lib/header.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:new_gradient_app_bar/new_gradient_app_bar.dart';
+
+class Header extends StatelessWidget with PreferredSizeWidget {
+  @override
+  Size get preferredSize => Size.fromHeight(kToolbarHeight);
+
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: NewGradientAppBar(
+            title: const Text('診断結果',
+                style: TextStyle(
+                    fontSize: 24,
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold)),
+            gradient: LinearGradient(
+              colors: [
+                Color(0xff7BD4F1).withOpacity(0.65),
+                Color(0xff220f60).withOpacity(1.0)
+              ],
+            )));
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,9 +25,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'HelloCircle',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
-        primaryColor: HexColor('220f60')
-      ),
+          primarySwatch: Colors.blue, primaryColor: HexColor('220f60')),
       // home: JudgeProcessPage(),//ExampleHomePage(),
       home: TitlePage(),
       routes: <String, WidgetBuilder>{

--- a/lib/resultpage.dart
+++ b/lib/resultpage.dart
@@ -4,9 +4,9 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:hello_world/header.dart';
 import 'package:hello_world/model/api.dart';
 import 'package:hello_world/resultdata.dart';
-import 'package:new_gradient_app_bar/new_gradient_app_bar.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_extend/share_extend.dart';
 
@@ -111,161 +111,166 @@ class _ResultPage extends State<ResultPage> {
         print('タップされました');
         detailDialog(context, imageUrl, circleName, introduction);
       },
+      child: Card(
+        margin: EdgeInsets.only(
+          top: 10,
+          right: 20,
+          left: 20,
+        ),
+        color: Colors.yellow,
+        child: Column(
+          children: [
+            Align(
+              alignment: Alignment.topLeft,
+              child: Stack(
+                children: [
+                  Container(
+                    color: Colors.teal,
+                    height: 43,
+                    width: MediaQuery.of(context).size.width * matchingRate,
+                  ), //メーター
+
+                  Container(
+                    margin: const EdgeInsets.only(left: 10),
+                    child: Text(
+                      '$circleName',
+                      style: TextStyle(
+                        fontSize: 30,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              color: Colors.lightGreen,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Image.network(
+                    imageUrl,
+                    width: 100,
+                    height: 100,
+                  ),
+                  Flexible(
+                    child: Container(
+                      child: Text(
+                        '$introduction',
+                        style: TextStyle(
+                          fontSize: 15,
+                        ),
+                      ),
+                      color: Colors.lightBlue,
+                      height: 110,
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
       // child: Card(
-      //   color: Colors.yellow,
-      //   child: Column(
-      //     children: [
-      //       Align(
-      //         alignment: Alignment.topLeft,
-      //         child: Stack(
-      //           children: [
-      //             Container(
-      //               color: Colors.teal,
-      //               height: 43,
-      //               width: MediaQuery.of(context).size.width * matchingRate,
-      //             ), //メーター
+      //     margin: EdgeInsets.only(
+      //       top: 20,
+      //       right: 20,
+      //       left: 20,
+      //     ),
+      //     shape: RoundedRectangleBorder(
+      //       borderRadius: BorderRadius.circular(5),
+      //     ),
+      //     color: Theme.of(context).primaryColor,
+      //     child: Column(
+      //       children: [
+      //         Align(
+      //           alignment: Alignment.topLeft,
+      //           child: Stack(
+      //             children: [
+      //               // TODO:メーターをタイトルボックスの真下に移植させたい
+      //               // CSSパラメータ参考:
+      //               // background: linear-gradient(90deg, #7BD4F1 38.55%, rgba(34, 15, 96, 0) 97.06%), #220F60;
+      //               // border-radius: 0px;
       //
-      //             Container(
-      //               margin: const EdgeInsets.only(left: 10),
-      //               child: Text(
-      //                 '$circleName',
-      //                 style: TextStyle(
-      //                   fontSize: 30,
-      //                 ),
-      //               ),
-      //             ),
-      //           ],
-      //         ),
-      //       ),
-      //       Container(
-      //         color: Colors.lightGreen,
-      //         child: Row(
-      //           crossAxisAlignment: CrossAxisAlignment.start,
-      //           children: [
-      //             Image.network(
-      //               imageUrl,
-      //               width: 100,
-      //               height: 100,
-      //             ),
-      //             Flexible(
-      //               child: Container(
+      //               // Container(
+      //               // color: Colors.teal,
+      //               // height: 43,
+      //               // width: MediaQuery.of(context).size.width * matchingRate,
+      //               // ), //メーター
+      //               // TODO: グラデーション
+      //               Container(
+      //                 padding: const EdgeInsets.all(3.0),
+      //                 margin: const EdgeInsets.only(left: 80, top: 1),
       //                 child: Text(
-      //                   '$introduction',
+      //                   '$circleName',
       //                   style: TextStyle(
-      //                     fontSize: 15,
+      //                     color: Colors.white,
+      //                     fontWeight: FontWeight.bold,
+      //                     fontSize: 12,
       //                   ),
       //                 ),
-      //                 color: Colors.lightBlue,
-      //                 height: 110,
       //               ),
-      //             )
-      //           ],
+      //               Container(
+      //                 padding: const EdgeInsets.all(3.0),
+      //                 margin: const EdgeInsets.only(left: 10, top: 1),
+      //                 decoration: BoxDecoration(
+      //                   borderRadius: BorderRadius.circular(30),
+      //                   color: Colors.white,
+      //                 ),
+      //                 child: Text(
+      //                   '1位',
+      //                   style: TextStyle(
+      //                     color: Theme.of(context).primaryColor,
+      //                     fontSize: 12,
+      //                   ),
+      //                 ),
+      //               ),
+      //               Container(
+      //                 padding: const EdgeInsets.all(3.0),
+      //                 margin: const EdgeInsets.only(left: 240, top: 1),
+      //                 decoration: BoxDecoration(
+      //                   borderRadius: BorderRadius.circular(30),
+      //                   color: Colors.white,
+      //                 ),
+      //                 child: Text(
+      //                   'おすすめ度' + (matchingRate.round() * 100).toString() + '%',
+      //                   style: TextStyle(
+      //                     color: Theme.of(context).primaryColor,
+      //                     fontSize: 12,
+      //                   ),
+      //                 ),
+      //               ),
+      //             ],
+      //           ),
       //         ),
-      //       ),
-      //     ],
-      //   ),
-      // ),
-      child: Card(
-          margin: EdgeInsets.only(
-            top: 20,
-            right: 20,
-            left: 20,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(5),
-          ),
-          color: Theme.of(context).primaryColor,
-          child: Column(
-            children: [
-              Align(
-                alignment: Alignment.topLeft,
-                child: Stack(
-                  children: [
-                    // TODO:メーターをタイトルボックスの真下に移植させたい
-                    // CSSパラメータ参考:
-                    // background: linear-gradient(90deg, #7BD4F1 38.55%, rgba(34, 15, 96, 0) 97.06%), #220F60;
-                    // border-radius: 0px;
-
-                    // Container(
-                    // color: Colors.teal,
-                    // height: 43,
-                    // width: MediaQuery.of(context).size.width * matchingRate,
-                    // ), //メーター
-                    // TODO: グラデーション
-                    Container(
-                      padding: const EdgeInsets.all(3.0),
-                      margin: const EdgeInsets.only(left: 80, top: 1),
-                      child: Text(
-                        '$circleName',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ),
-                    Container(
-                      padding: const EdgeInsets.all(3.0),
-                      margin: const EdgeInsets.only(left: 10, top: 1),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(30),
-                        color: Colors.white,
-                      ),
-                      child: Text(
-                        '1位',
-                        style: TextStyle(
-                          color: Theme.of(context).primaryColor,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ),
-                    Container(
-                      padding: const EdgeInsets.all(3.0),
-                      margin: const EdgeInsets.only(left: 240, top: 1),
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(30),
-                        color: Colors.white,
-                      ),
-                      child: Text(
-                        'おすすめ度' + (matchingRate.round() * 100).toString() + '%',
-                        style: TextStyle(
-                          color: Theme.of(context).primaryColor,
-                          fontSize: 12,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Container(
-                padding: const EdgeInsets.all(3.0),
-                color: Colors.white,
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Image.network(
-                      imageUrl,
-                      width: 100,
-                      height: 100,
-                    ),
-                    Flexible(
-                      child: Container(
-                        child: Text(
-                          '$introduction',
-                          style: TextStyle(
-                            fontSize: 15,
-                            color: Theme.of(context).primaryColor,
-                          ),
-                        ),
-                        color: Colors.white,
-                        height: 110,
-                      ),
-                    )
-                  ],
-                ),
-              ),
-            ],
-          )),
+      //             Container(
+      //               padding: const EdgeInsets.all(3.0),
+      //               color: Colors.white,
+      //               child: Row(
+      //                 crossAxisAlignment: CrossAxisAlignment.start,
+      //                 children: [
+      //                   Image.network(
+      //                     imageUrl,
+      //                     width: 100,
+      //                     height: 100,
+      //                   ),
+      //                   Flexible(
+      //                     child: Container(
+      //                       child: Text(
+      //                         '$introduction',
+      //                         style: TextStyle(
+      //                           fontSize: 15,
+      //                           color: Theme.of(context).primaryColor,
+      //                         ),
+      //                       ),
+      //                       color: Colors.white,
+      //                       height: 110,
+      //                     ),
+      //                   )
+      //                 ],
+      //               ),
+      //             ),
+      //           ],
+      //         )),
     );
   }
 
@@ -278,7 +283,7 @@ class _ResultPage extends State<ResultPage> {
       },
       child: Card(
           margin: EdgeInsets.only(
-            top: 20,
+            top: 10,
             right: 20,
             left: 20,
           ),
@@ -380,45 +385,40 @@ class _ResultPage extends State<ResultPage> {
     );
   }
 
-  // TODO: margin調整
   Widget buttons(context) {
-    return Align(
-      alignment: Alignment.bottomCenter,
-      child: Container(
-        height: 90,
-        margin: const EdgeInsets.only(top: 33),
-        color: Theme.of(context).primaryColor,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                primary: Colors.white,
-                shape: const CircleBorder(),
-              ),
-              onPressed: () => shareImageAndText('result', shareKey),
-              child: const Icon(
-                Icons.share,
+    return Container(
+      height: 90,
+      color: Theme.of(context).primaryColor,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              primary: Colors.white,
+              shape: const CircleBorder(),
+            ),
+            onPressed: () => shareImageAndText('result', shareKey),
+            child: const Icon(
+              Icons.share,
+              color: Colors.black,
+            ),
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              primary: Colors.white,
+            ),
+            onPressed: () {
+              Navigator.of(context).pushNamed("/title");
+            },
+            child: const Text(
+              'タイトルへ',
+              style: TextStyle(
                 color: Colors.black,
+                fontSize: 12,
               ),
             ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                primary: Colors.white,
-              ),
-              onPressed: () {
-                Navigator.of(context).pushNamed("/title");
-              },
-              child: const Text(
-                'タイトルへ',
-                style: TextStyle(
-                  color: Colors.black,
-                  fontSize: 18,
-                ),
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -474,47 +474,35 @@ class _ResultPage extends State<ResultPage> {
     return RepaintBoundary(
       key: shareKey,
       child: Scaffold(
-          appBar: NewGradientAppBar(
-            title: const Text('診断結果',
-                style: TextStyle(
-                    fontSize: 24,
-                    color: Colors.white,
-                    fontWeight: FontWeight.bold)),
-            gradient: LinearGradient(
-              colors: [
-                Color(0xff7BD4F1).withOpacity(0.65),
-                Color(0xff220f60).withOpacity(1.0)
+        appBar: Header(),
+        body: SafeArea(
+          child: Center(
+            child: Column(
+              children: [
+                firstCard(
+                    context,
+                    resultLoad(0).circlename,
+                    resultLoad(0).percent,
+                    resultLoad(0).circle_description,
+                    resultLoad(0).circle_image_url),
+                secondThirdCard(
+                    context,
+                    resultLoad(1).circlename,
+                    resultLoad(1).percent,
+                    resultLoad(1).circle_description,
+                    resultLoad(1).circle_image_url),
+                secondThirdCard(
+                    context,
+                    resultLoad(2).circlename,
+                    resultLoad(2).percent,
+                    resultLoad(2).circle_description,
+                    resultLoad(2).circle_image_url)
               ],
             ),
           ),
-          body: SafeArea(
-            child: Center(
-              child: Column(
-                children: [
-                  // header(),
-                  firstCard(
-                      context,
-                      resultLoad(0).circlename,
-                      resultLoad(0).percent,
-                      resultLoad(0).circle_description,
-                      resultLoad(0).circle_image_url),
-                  secondThirdCard(
-                      context,
-                      resultLoad(1).circlename,
-                      resultLoad(1).percent,
-                      resultLoad(1).circle_description,
-                      resultLoad(1).circle_image_url),
-                  secondThirdCard(
-                      context,
-                      resultLoad(2).circlename,
-                      resultLoad(2).percent,
-                      resultLoad(2).circle_description,
-                      resultLoad(2).circle_image_url),
-                  buttons(context),
-                ],
-              ),
-            ),
-          )),
+        ),
+        bottomNavigationBar: buttons(context),
+      ),
     );
   }
 

--- a/lib/resultpage.dart
+++ b/lib/resultpage.dart
@@ -170,107 +170,6 @@ class _ResultPage extends State<ResultPage> {
           ],
         ),
       ),
-      // child: Card(
-      //     margin: EdgeInsets.only(
-      //       top: 20,
-      //       right: 20,
-      //       left: 20,
-      //     ),
-      //     shape: RoundedRectangleBorder(
-      //       borderRadius: BorderRadius.circular(5),
-      //     ),
-      //     color: Theme.of(context).primaryColor,
-      //     child: Column(
-      //       children: [
-      //         Align(
-      //           alignment: Alignment.topLeft,
-      //           child: Stack(
-      //             children: [
-      //               // TODO:メーターをタイトルボックスの真下に移植させたい
-      //               // CSSパラメータ参考:
-      //               // background: linear-gradient(90deg, #7BD4F1 38.55%, rgba(34, 15, 96, 0) 97.06%), #220F60;
-      //               // border-radius: 0px;
-      //
-      //               // Container(
-      //               // color: Colors.teal,
-      //               // height: 43,
-      //               // width: MediaQuery.of(context).size.width * matchingRate,
-      //               // ), //メーター
-      //               // TODO: グラデーション
-      //               Container(
-      //                 padding: const EdgeInsets.all(3.0),
-      //                 margin: const EdgeInsets.only(left: 80, top: 1),
-      //                 child: Text(
-      //                   '$circleName',
-      //                   style: TextStyle(
-      //                     color: Colors.white,
-      //                     fontWeight: FontWeight.bold,
-      //                     fontSize: 12,
-      //                   ),
-      //                 ),
-      //               ),
-      //               Container(
-      //                 padding: const EdgeInsets.all(3.0),
-      //                 margin: const EdgeInsets.only(left: 10, top: 1),
-      //                 decoration: BoxDecoration(
-      //                   borderRadius: BorderRadius.circular(30),
-      //                   color: Colors.white,
-      //                 ),
-      //                 child: Text(
-      //                   '1位',
-      //                   style: TextStyle(
-      //                     color: Theme.of(context).primaryColor,
-      //                     fontSize: 12,
-      //                   ),
-      //                 ),
-      //               ),
-      //               Container(
-      //                 padding: const EdgeInsets.all(3.0),
-      //                 margin: const EdgeInsets.only(left: 240, top: 1),
-      //                 decoration: BoxDecoration(
-      //                   borderRadius: BorderRadius.circular(30),
-      //                   color: Colors.white,
-      //                 ),
-      //                 child: Text(
-      //                   'おすすめ度' + (matchingRate.round() * 100).toString() + '%',
-      //                   style: TextStyle(
-      //                     color: Theme.of(context).primaryColor,
-      //                     fontSize: 12,
-      //                   ),
-      //                 ),
-      //               ),
-      //             ],
-      //           ),
-      //         ),
-      //             Container(
-      //               padding: const EdgeInsets.all(3.0),
-      //               color: Colors.white,
-      //               child: Row(
-      //                 crossAxisAlignment: CrossAxisAlignment.start,
-      //                 children: [
-      //                   Image.network(
-      //                     imageUrl,
-      //                     width: 100,
-      //                     height: 100,
-      //                   ),
-      //                   Flexible(
-      //                     child: Container(
-      //                       child: Text(
-      //                         '$introduction',
-      //                         style: TextStyle(
-      //                           fontSize: 15,
-      //                           color: Theme.of(context).primaryColor,
-      //                         ),
-      //                       ),
-      //                       color: Colors.white,
-      //                       height: 110,
-      //                     ),
-      //                   )
-      //                 ],
-      //               ),
-      //             ),
-      //           ],
-      //         )),
     );
   }
 
@@ -297,17 +196,6 @@ class _ResultPage extends State<ResultPage> {
                 alignment: Alignment.topLeft,
                 child: Stack(
                   children: [
-                    // TODO:メーターをタイトルボックスの真下に移植させたい
-                    // CSSパラメータ参考:
-                    // background: linear-gradient(90deg, #7BD4F1 38.55%, rgba(34, 15, 96, 0) 97.06%), #220F60;
-                    // border-radius: 0px;
-
-                    // Container(
-                    // color: Colors.teal,
-                    // height: 43,
-                    // width: MediaQuery.of(context).size.width * matchingRate,
-                    // ), //メーター
-                    // TODO: グラデーション
                     Container(
                       padding: const EdgeInsets.all(3.0),
                       margin: const EdgeInsets.only(left: 80, top: 1),
@@ -354,15 +242,44 @@ class _ResultPage extends State<ResultPage> {
                 ),
               ),
               Container(
+                padding: const EdgeInsets.only(top: 3.0),
+                color: Colors.white,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Align(
+                      alignment: Alignment.topLeft,
+                      child: Stack(
+                        children: [
+                          Container(
+                            color: Colors.teal,
+                            height: 5,
+                            width: MediaQuery.of(context).size.width *
+                                matchingRate,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
                 padding: const EdgeInsets.all(3.0),
                 color: Colors.white,
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Image.network(
-                      imageUrl,
-                      width: 100,
-                      height: 100,
+                    Align(
+                      alignment: Alignment.topLeft,
+                      child: Stack(
+                        children: [
+                          Image.network(
+                            imageUrl,
+                            width: 100,
+                            height: 100,
+                          ),
+                        ],
+                      ),
                     ),
                     Flexible(
                       child: Container(

--- a/lib/resultpage.dart
+++ b/lib/resultpage.dart
@@ -6,6 +6,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:hello_world/model/api.dart';
 import 'package:hello_world/resultdata.dart';
+import 'package:new_gradient_app_bar/new_gradient_app_bar.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_extend/share_extend.dart';
 
@@ -66,24 +67,38 @@ class _ResultPage extends State<ResultPage> {
 
   Widget header() {
     return Container(
-      margin: const EdgeInsets.symmetric(vertical: 10),
-      color: Theme.of(context).primaryColor,
+      alignment: Alignment.centerLeft,
+      padding: const EdgeInsets.all(12),
+      width: double.infinity,
+      height: 90,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: FractionalOffset.topLeft,
+          end: FractionalOffset.bottomRight,
+          colors: [
+            const Color(0xff7BD4F1).withOpacity(0.65),
+            const Color(0xff220f60).withOpacity(1.0),
+          ],
+          stops: const [
+            0.0,
+            1.0,
+          ],
+        ),
+      ),
       child: Column(
         children: [
-          const Text(
-            '診断結果',
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: 35,
-            ),
-          ),
-          const Text(
-            'あなたにおすすめのサークルは....',
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: 25,
-            ),
-          ),
+          const Text('診断結果',
+              style: TextStyle(
+                  fontSize: 30,
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold)),
+          // const Text(
+          //   'あなたにおすすめのサークルは....',
+          //   style: TextStyle(
+          //     fontSize: 20,
+          //     color: Colors.white,
+          //   ),
+          // ),
         ],
       ),
     );
@@ -184,18 +199,19 @@ class _ResultPage extends State<ResultPage> {
                     // TODO: グラデーション
                     Container(
                       padding: const EdgeInsets.all(3.0),
-                      margin: const EdgeInsets.only(left: 80, top: 2),
+                      margin: const EdgeInsets.only(left: 80, top: 1),
                       child: Text(
                         '$circleName',
                         style: TextStyle(
                           color: Colors.white,
-                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 18,
                         ),
                       ),
                     ),
                     Container(
                       padding: const EdgeInsets.all(3.0),
-                      margin: const EdgeInsets.only(left: 10, top: 2),
+                      margin: const EdgeInsets.only(left: 10, top: 1),
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(30),
                         color: Colors.white,
@@ -203,14 +219,14 @@ class _ResultPage extends State<ResultPage> {
                       child: Text(
                         '1位',
                         style: TextStyle(
-                          color: Colors.black,
-                          fontSize: 20,
+                          color: Theme.of(context).primaryColor,
+                          fontSize: 18,
                         ),
                       ),
                     ),
                     Container(
                       padding: const EdgeInsets.all(3.0),
-                      margin: const EdgeInsets.only(left: 240, top: 2),
+                      margin: const EdgeInsets.only(left: 240, top: 1),
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(30),
                         color: Colors.white,
@@ -218,8 +234,8 @@ class _ResultPage extends State<ResultPage> {
                       child: Text(
                         'おすすめ度' + (matchingRate.round() * 100).toString() + '%',
                         style: TextStyle(
-                          color: Colors.black,
-                          fontSize: 20,
+                          color: Theme.of(context).primaryColor,
+                          fontSize: 18,
                         ),
                       ),
                     ),
@@ -243,6 +259,7 @@ class _ResultPage extends State<ResultPage> {
                           '$introduction',
                           style: TextStyle(
                             fontSize: 15,
+                            color: Theme.of(context).primaryColor,
                           ),
                         ),
                         color: Colors.white,
@@ -350,34 +367,47 @@ class _ResultPage extends State<ResultPage> {
     return RepaintBoundary(
       key: shareKey,
       child: Scaffold(
-          body: SafeArea(
-        child: Center(
-          child: Column(
-            children: [
-              header(),
-              firstCard(
-                  context,
-                  resultLoad(0).circlename,
-                  resultLoad(0).percent,
-                  resultLoad(0).circle_description,
-                  resultLoad(0).circle_image_url),
-              secondThirdCard(
-                  context,
-                  resultLoad(1).circlename,
-                  resultLoad(1).percent,
-                  resultLoad(1).circle_description,
-                  resultLoad(1).circle_image_url),
-              secondThirdCard(
-                  context,
-                  resultLoad(2).circlename,
-                  resultLoad(2).percent,
-                  resultLoad(2).circle_description,
-                  resultLoad(2).circle_image_url),
-              buttons(context),
-            ],
+          appBar: NewGradientAppBar(
+            title: const Text('診断結果',
+                style: TextStyle(
+                    fontSize: 24,
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold)),
+            gradient: LinearGradient(
+              colors: [
+                Color(0xff7BD4F1).withOpacity(0.65),
+                Color(0xff220f60).withOpacity(1.0)
+              ],
+            ),
           ),
-        ),
-      )),
+          body: SafeArea(
+            child: Center(
+              child: Column(
+                children: [
+                  // header(),
+                  firstCard(
+                      context,
+                      resultLoad(0).circlename,
+                      resultLoad(0).percent,
+                      resultLoad(0).circle_description,
+                      resultLoad(0).circle_image_url),
+                  secondThirdCard(
+                      context,
+                      resultLoad(1).circlename,
+                      resultLoad(1).percent,
+                      resultLoad(1).circle_description,
+                      resultLoad(1).circle_image_url),
+                  secondThirdCard(
+                      context,
+                      resultLoad(2).circlename,
+                      resultLoad(2).percent,
+                      resultLoad(2).circle_description,
+                      resultLoad(2).circle_image_url),
+                  buttons(context),
+                ],
+              ),
+            ),
+          )),
     );
   }
 

--- a/lib/resultpage.dart
+++ b/lib/resultpage.dart
@@ -1,18 +1,17 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:hello_world/model/api.dart';
 import 'package:hello_world/resultdata.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_extend/share_extend.dart';
-import 'package:hello_world/model/api.dart';
-import 'dart:ui' as ui;
-import 'dart:io';
-
 
 class ResultPage extends StatefulWidget {
   @override
   _ResultPage createState() => _ResultPage();
-
 }
 
 class _ResultPage extends State<ResultPage> {
@@ -23,17 +22,20 @@ class _ResultPage extends State<ResultPage> {
       print("finish_load");
     });
   }
-  detailDialog(context,String imageUrl,String circleName,String introduction) {
+
+  detailDialog(
+      context, String imageUrl, String circleName, String introduction) {
     showDialog(
         context: context,
         builder: (BuildContext context) => AlertDialog(
               title: Column(
                 children: [
-                  Image.network(
-                     imageUrl ),
+                  Image.network(imageUrl),
                   Text(
                     circleName,
-                    style: TextStyle(fontSize: 25),
+                    style: TextStyle(
+                      fontSize: 25,
+                    ),
                   )
                 ],
               ),
@@ -65,18 +67,20 @@ class _ResultPage extends State<ResultPage> {
   Widget header() {
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 10),
-      color: Colors.grey,
+      color: Theme.of(context).primaryColor,
       child: Column(
         children: [
           const Text(
             '診断結果',
             style: TextStyle(
+              color: Colors.white,
               fontSize: 35,
             ),
           ),
           const Text(
             'あなたにおすすめのサークルは....',
             style: TextStyle(
+              color: Colors.white,
               fontSize: 25,
             ),
           ),
@@ -85,12 +89,12 @@ class _ResultPage extends State<ResultPage> {
     );
   }
 
-  Widget firstCard(
-      context, String circleName, double matchingRate, String introduction,String imageUrl) {
+  Widget firstCard(context, String circleName, double matchingRate,
+      String introduction, String imageUrl) {
     return GestureDetector(
       onTap: () {
         print('タップされました');
-        detailDialog(context,imageUrl,circleName,introduction);
+        detailDialog(context, imageUrl, circleName, introduction);
       },
       child: Card(
         color: Colors.yellow,
@@ -124,7 +128,10 @@ class _ResultPage extends State<ResultPage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Image.network(
-                    imageUrl,width: 100,height: 100,),
+                    imageUrl,
+                    width: 100,
+                    height: 100,
+                  ),
                   Flexible(
                     child: Container(
                       child: Text(
@@ -146,33 +153,73 @@ class _ResultPage extends State<ResultPage> {
     );
   }
 
-  Widget secondThirdCard(
-      context, String circleName, double matchingRate, String introduction,String imageUrl) {
+  Widget secondThirdCard(context, String circleName, double matchingRate,
+      String introduction, String imageUrl) {
     return GestureDetector(
       onTap: () {
         print('タップされました');
-        detailDialog(context,imageUrl,circleName,introduction);
+        detailDialog(context, imageUrl, circleName, introduction);
       },
       child: Card(
-          color: Colors.yellow,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(5),
+          ),
+          color: Theme.of(context).primaryColor,
           child: Column(
             children: [
               Align(
                 alignment: Alignment.topLeft,
                 child: Stack(
                   children: [
-                    Container(
-                      color: Colors.teal,
-                      height: 43,
-                      width: MediaQuery.of(context).size.width * matchingRate,
-                    ), //メーター
+                    // TODO:メーターをタイトルボックスの真下に移植させたい
+                    // CSSパラメータ参考:
+                    // background: linear-gradient(90deg, #7BD4F1 38.55%, rgba(34, 15, 96, 0) 97.06%), #220F60;
+                    // border-radius: 0px;
 
+                    // Container(
+                    // color: Colors.teal,
+                    // height: 43,
+                    // width: MediaQuery.of(context).size.width * matchingRate,
+                    // ), //メーター
+                    // TODO: グラデーション
                     Container(
-                      margin: const EdgeInsets.only(left: 10),
+                      padding: const EdgeInsets.all(3.0),
+                      margin: const EdgeInsets.only(left: 80, top: 2),
                       child: Text(
                         '$circleName',
                         style: TextStyle(
-                          fontSize: 30,
+                          color: Colors.white,
+                          fontSize: 20,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      padding: const EdgeInsets.all(3.0),
+                      margin: const EdgeInsets.only(left: 10, top: 2),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: Colors.white,
+                      ),
+                      child: Text(
+                        '1位',
+                        style: TextStyle(
+                          color: Colors.black,
+                          fontSize: 20,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      padding: const EdgeInsets.all(3.0),
+                      margin: const EdgeInsets.only(left: 240, top: 2),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: Colors.white,
+                      ),
+                      child: Text(
+                        'おすすめ度' + (matchingRate.round() * 100).toString() + '%',
+                        style: TextStyle(
+                          color: Colors.black,
+                          fontSize: 20,
                         ),
                       ),
                     ),
@@ -180,15 +227,31 @@ class _ResultPage extends State<ResultPage> {
                 ),
               ),
               Container(
-                child: Text(
-                  '$introduction',
-                  style: TextStyle(
-                    fontSize: 15,
-                  ),
+                padding: const EdgeInsets.all(3.0),
+                color: Colors.white,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Image.network(
+                      imageUrl,
+                      width: 100,
+                      height: 100,
+                    ),
+                    Flexible(
+                      child: Container(
+                        child: Text(
+                          '$introduction',
+                          style: TextStyle(
+                            fontSize: 15,
+                          ),
+                        ),
+                        color: Colors.white,
+                        height: 110,
+                      ),
+                    )
+                  ],
                 ),
-                color: Colors.lightBlue,
-                height: 88,
-              )
+              ),
             ],
           )),
     );
@@ -198,23 +261,38 @@ class _ResultPage extends State<ResultPage> {
     return Align(
       alignment: Alignment.bottomCenter,
       child: Container(
+        height: 90,
         margin: const EdgeInsets.only(top: 40),
-        color: Colors.orange,
+        color: Theme.of(context).primaryColor,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                primary: Colors.white,
                 shape: const CircleBorder(),
               ),
               onPressed: () => shareImageAndText('result', shareKey),
-              child: const Icon(Icons.share),
+              child: const Icon(
+                Icons.share,
+                color: Colors.black,
+              ),
             ),
             ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).pushNamed("/title");
-                },
-                child: const Text('タイトルへ')),
+              style: ElevatedButton.styleFrom(
+                primary: Colors.white,
+              ),
+              onPressed: () {
+                Navigator.of(context).pushNamed("/title");
+              },
+              child: const Text(
+                'タイトルへ',
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 18,
+                ),
+              ),
+            ),
           ],
         ),
       ),
@@ -273,27 +351,44 @@ class _ResultPage extends State<ResultPage> {
       key: shareKey,
       child: Scaffold(
           body: SafeArea(
-        child: Center( 
-            child: Column(
-              children: [
-                header(),
-                firstCard(context, resultLoad(0).circlename, resultLoad(0).percent,
-                    resultLoad(0).circle_description,resultLoad(0).circle_image_url),
-                secondThirdCard(context, resultLoad(1).circlename, resultLoad(1).percent,
-                    resultLoad(1).circle_description,resultLoad(1).circle_image_url),
-                secondThirdCard(context, resultLoad(2).circlename, resultLoad(2).percent,
-                    resultLoad(2).circle_description,resultLoad(2).circle_image_url),
-                buttons(context),
-              ],
-            ),
+        child: Center(
+          child: Column(
+            children: [
+              header(),
+              firstCard(
+                  context,
+                  resultLoad(0).circlename,
+                  resultLoad(0).percent,
+                  resultLoad(0).circle_description,
+                  resultLoad(0).circle_image_url),
+              secondThirdCard(
+                  context,
+                  resultLoad(1).circlename,
+                  resultLoad(1).percent,
+                  resultLoad(1).circle_description,
+                  resultLoad(1).circle_image_url),
+              secondThirdCard(
+                  context,
+                  resultLoad(2).circlename,
+                  resultLoad(2).percent,
+                  resultLoad(2).circle_description,
+                  resultLoad(2).circle_image_url),
+              buttons(context),
+            ],
+          ),
         ),
       )),
     );
   }
 
-  Result resultLoad(int num){
-    if(ResultData().GetCircle(num)==null){
-      return Result(0, "読み込み中", 0, 'https://github.com/618knot/circle_judge/blob/main/images/panel001.png?raw=true', "読み込み中");
+  Result resultLoad(int num) {
+    if (ResultData().GetCircle(num) == null) {
+      return Result(
+          0,
+          "読み込み中",
+          0,
+          'https://github.com/618knot/circle_judge/blob/main/images/panel001.png?raw=true',
+          "読み込み中");
     }
     return ResultData().GetCircle(num);
   }

--- a/lib/resultpage.dart
+++ b/lib/resultpage.dart
@@ -65,45 +65,6 @@ class _ResultPage extends State<ResultPage> {
             ));
   }
 
-  Widget header() {
-    return Container(
-      alignment: Alignment.centerLeft,
-      padding: const EdgeInsets.all(12),
-      width: double.infinity,
-      height: 90,
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: FractionalOffset.topLeft,
-          end: FractionalOffset.bottomRight,
-          colors: [
-            const Color(0xff7BD4F1).withOpacity(0.65),
-            const Color(0xff220f60).withOpacity(1.0),
-          ],
-          stops: const [
-            0.0,
-            1.0,
-          ],
-        ),
-      ),
-      child: Column(
-        children: [
-          const Text('診断結果',
-              style: TextStyle(
-                  fontSize: 30,
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold)),
-          // const Text(
-          //   'あなたにおすすめのサークルは....',
-          //   style: TextStyle(
-          //     fontSize: 20,
-          //     color: Colors.white,
-          //   ),
-          // ),
-        ],
-      ),
-    );
-  }
-
   Widget firstCard(context, String circleName, double matchingRate,
       String introduction, String imageUrl) {
     return GestureDetector(

--- a/lib/resultpage.dart
+++ b/lib/resultpage.dart
@@ -111,71 +111,66 @@ class _ResultPage extends State<ResultPage> {
         print('タップされました');
         detailDialog(context, imageUrl, circleName, introduction);
       },
+      // child: Card(
+      //   color: Colors.yellow,
+      //   child: Column(
+      //     children: [
+      //       Align(
+      //         alignment: Alignment.topLeft,
+      //         child: Stack(
+      //           children: [
+      //             Container(
+      //               color: Colors.teal,
+      //               height: 43,
+      //               width: MediaQuery.of(context).size.width * matchingRate,
+      //             ), //メーター
+      //
+      //             Container(
+      //               margin: const EdgeInsets.only(left: 10),
+      //               child: Text(
+      //                 '$circleName',
+      //                 style: TextStyle(
+      //                   fontSize: 30,
+      //                 ),
+      //               ),
+      //             ),
+      //           ],
+      //         ),
+      //       ),
+      //       Container(
+      //         color: Colors.lightGreen,
+      //         child: Row(
+      //           crossAxisAlignment: CrossAxisAlignment.start,
+      //           children: [
+      //             Image.network(
+      //               imageUrl,
+      //               width: 100,
+      //               height: 100,
+      //             ),
+      //             Flexible(
+      //               child: Container(
+      //                 child: Text(
+      //                   '$introduction',
+      //                   style: TextStyle(
+      //                     fontSize: 15,
+      //                   ),
+      //                 ),
+      //                 color: Colors.lightBlue,
+      //                 height: 110,
+      //               ),
+      //             )
+      //           ],
+      //         ),
+      //       ),
+      //     ],
+      //   ),
+      // ),
       child: Card(
-        color: Colors.yellow,
-        child: Column(
-          children: [
-            Align(
-              alignment: Alignment.topLeft,
-              child: Stack(
-                children: [
-                  Container(
-                    color: Colors.teal,
-                    height: 43,
-                    width: MediaQuery.of(context).size.width * matchingRate,
-                  ), //メーター
-
-                  Container(
-                    margin: const EdgeInsets.only(left: 10),
-                    child: Text(
-                      '$circleName',
-                      style: TextStyle(
-                        fontSize: 30,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Container(
-              color: Colors.lightGreen,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Image.network(
-                    imageUrl,
-                    width: 100,
-                    height: 100,
-                  ),
-                  Flexible(
-                    child: Container(
-                      child: Text(
-                        '$introduction',
-                        style: TextStyle(
-                          fontSize: 15,
-                        ),
-                      ),
-                      color: Colors.lightBlue,
-                      height: 110,
-                    ),
-                  )
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget secondThirdCard(context, String circleName, double matchingRate,
-      String introduction, String imageUrl) {
-    return GestureDetector(
-      onTap: () {
-        print('タップされました');
-        detailDialog(context, imageUrl, circleName, introduction);
-      },
-      child: Card(
+          margin: EdgeInsets.only(
+            top: 20,
+            right: 20,
+            left: 20,
+          ),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(5),
           ),
@@ -205,7 +200,7 @@ class _ResultPage extends State<ResultPage> {
                         style: TextStyle(
                           color: Colors.white,
                           fontWeight: FontWeight.bold,
-                          fontSize: 18,
+                          fontSize: 12,
                         ),
                       ),
                     ),
@@ -220,7 +215,7 @@ class _ResultPage extends State<ResultPage> {
                         '1位',
                         style: TextStyle(
                           color: Theme.of(context).primaryColor,
-                          fontSize: 18,
+                          fontSize: 12,
                         ),
                       ),
                     ),
@@ -235,7 +230,7 @@ class _ResultPage extends State<ResultPage> {
                         'おすすめ度' + (matchingRate.round() * 100).toString() + '%',
                         style: TextStyle(
                           color: Theme.of(context).primaryColor,
-                          fontSize: 18,
+                          fontSize: 12,
                         ),
                       ),
                     ),
@@ -274,12 +269,124 @@ class _ResultPage extends State<ResultPage> {
     );
   }
 
+  Widget secondThirdCard(context, String circleName, double matchingRate,
+      String introduction, String imageUrl) {
+    return GestureDetector(
+      onTap: () {
+        print('タップされました');
+        detailDialog(context, imageUrl, circleName, introduction);
+      },
+      child: Card(
+          margin: EdgeInsets.only(
+            top: 20,
+            right: 20,
+            left: 20,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(5),
+          ),
+          color: Theme.of(context).primaryColor,
+          child: Column(
+            children: [
+              Align(
+                alignment: Alignment.topLeft,
+                child: Stack(
+                  children: [
+                    // TODO:メーターをタイトルボックスの真下に移植させたい
+                    // CSSパラメータ参考:
+                    // background: linear-gradient(90deg, #7BD4F1 38.55%, rgba(34, 15, 96, 0) 97.06%), #220F60;
+                    // border-radius: 0px;
+
+                    // Container(
+                    // color: Colors.teal,
+                    // height: 43,
+                    // width: MediaQuery.of(context).size.width * matchingRate,
+                    // ), //メーター
+                    // TODO: グラデーション
+                    Container(
+                      padding: const EdgeInsets.all(3.0),
+                      margin: const EdgeInsets.only(left: 80, top: 1),
+                      child: Text(
+                        '$circleName',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      padding: const EdgeInsets.all(3.0),
+                      margin: const EdgeInsets.only(left: 10, top: 1),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: Colors.white,
+                      ),
+                      child: Text(
+                        '1位',
+                        style: TextStyle(
+                          color: Theme.of(context).primaryColor,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      padding: const EdgeInsets.all(3.0),
+                      margin: const EdgeInsets.only(left: 240, top: 1),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: Colors.white,
+                      ),
+                      child: Text(
+                        'おすすめ度' + (matchingRate.round() * 100).toString() + '%',
+                        style: TextStyle(
+                          color: Theme.of(context).primaryColor,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.all(3.0),
+                color: Colors.white,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Image.network(
+                      imageUrl,
+                      width: 100,
+                      height: 100,
+                    ),
+                    Flexible(
+                      child: Container(
+                        child: Text(
+                          '$introduction',
+                          style: TextStyle(
+                            fontSize: 15,
+                            color: Theme.of(context).primaryColor,
+                          ),
+                        ),
+                        color: Colors.white,
+                        height: 110,
+                      ),
+                    )
+                  ],
+                ),
+              ),
+            ],
+          )),
+    );
+  }
+
+  // TODO: margin調整
   Widget buttons(context) {
     return Align(
       alignment: Alignment.bottomCenter,
       child: Container(
         height: 90,
-        margin: const EdgeInsets.only(top: 40),
+        margin: const EdgeInsets.only(top: 33),
         color: Theme.of(context).primaryColor,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -172,6 +172,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  new_gradient_app_bar:
+    dependency: "direct main"
+    description:
+      name: new_gradient_app_bar
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
   swipeable_stack: #
+  new_gradient_app_bar: ^0.2.0
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
fixed #85 #87
Figmaに合わせてレイアウトを仮組みしました。
実装の比較・参考のため1つ目のカードは元の状態のままにしています。見てもらって問題なさそうであれば統一します。
ヘッダークラスを切り出したため、いじれば診断中ページに使いまわし可能になっています（テキストを変数値にしてそれぞれのクラスから渡してあげるとよさそう）  
  
このPRでは以下の機能が未実装です。
- パーセンテージバーをグラデーションの度合いと連動させて変化させる
- 順位を変数化する
- フォント

検討したいこと
- フォントサイズ
  - 現状はレイアウトが崩れない大きさにしていますがエミュレータだと小さすぎるので調整が必要そうです。実機を想定した適正サイズが知りたみです。

参考
![image](https://user-images.githubusercontent.com/60646787/160748105-1631c5ab-4ee8-4e40-b79f-981408715848.png)