### PR TITLE
Fix 91 refactor header

### DIFF
--- a/lib/header.dart
+++ b/lib/header.dart
@@ -2,14 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:new_gradient_app_bar/new_gradient_app_bar.dart';
 
 class Header extends StatelessWidget with PreferredSizeWidget {
+  String title = '';
+  Header(String title){
+    this.title = title;
+  }
   @override
   Size get preferredSize => Size.fromHeight(kToolbarHeight);
 
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: NewGradientAppBar(
-            title: const Text('診断結果',
-                style: TextStyle(
+            title: Text(title,
+                style: const TextStyle(
                     fontSize: 24,
                     color: Colors.white,
                     fontWeight: FontWeight.bold)),

--- a/lib/judgeProcessPage.dart
+++ b/lib/judgeProcessPage.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hello_world/model/api.dart';
 import 'package:hello_world/tinderCards.dart';
 import 'package:hello_world/ProgressDotsBar.dart';
-
+import 'package:hello_world/header.dart';
 class JudgeProcessPage extends StatefulWidget {
   judgeProcessPage() {
     //getController().stream.listen((event) {print("イベント");});
@@ -65,7 +65,7 @@ class _JudgeProcessPageState extends State<JudgeProcessPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("診断中")),
+      appBar: Header('診断中'),
       body: Column(
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/resultpage.dart
+++ b/lib/resultpage.dart
@@ -352,7 +352,7 @@ class _ResultPage extends State<ResultPage> {
     return RepaintBoundary(
       key: shareKey,
       child: Scaffold(
-        appBar: Header(),
+        appBar: Header('診断結果'),
         body: SafeArea(
           child: Center(
             child: Column(


### PR DESCRIPTION
Headerを診断ページで使いたかったので,titleを外から持てるように変更し、診断結果ページの該当箇所も呼び出し方を更新しました。